### PR TITLE
BUG: Change font source to https

### DIFF
--- a/_includes/externals/styling.html
+++ b/_includes/externals/styling.html
@@ -1,4 +1,4 @@
-<link href='http://fonts.googleapis.com/css?family=Inconsolata:400,700' rel='stylesheet' type='text/css'>
+<link href='https://fonts.googleapis.com/css?family=Inconsolata:400,700' rel='stylesheet' type='text/css'>
 <link rel="stylesheet" href="{{ "/assets/vendor/normalize-css/normalize.css" | prepend: site.baseurl }}">
 <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
 <link rel="stylesheet" href="{{ "/assets/vendor/highlight/styles/solarized_dark.css" | prepend: site.baseurl }}">


### PR DESCRIPTION
closes #71. Load the fonts from an https source. This allows the https version of the webpage to load the correct font without breaking the https version.