### PR TITLE
MAINT: update PubMed url to sort by date

### DIFF
--- a/publications.html
+++ b/publications.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Publications
-subtitle: Caporaso Lab publications via <a target="_blank" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?db=pubmed&cmd=Search&term=%22Caporaso+JG%22%5BAuthor%5D">PubMed</a> or <a target="_blank" href="http://scholar.google.com/citations?hl=en&user=8wv9sLkAAAAJ">Google Scholar</a>.
+subtitle: Caporaso Lab publications via <a target="_blank" href="https://pubmed.ncbi.nlm.nih.gov/?term=%22Caporaso+JG%22%5BAuthor%5D&sort=date">PubMed</a> or <a target="_blank" href="http://scholar.google.com/citations?hl=en&user=8wv9sLkAAAAJ">Google Scholar</a>.
 permalink: /publications/
 color: orange
 ---


### PR DESCRIPTION
i *think* this used to be the default, but now it seems to sort by "Most relevant" by default

tested locally and this works as expected now. 